### PR TITLE
v1.13.0: Stacked Deck & In-Place Reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format: `[version] — date — summary`
 
 ---
 
+## [1.13.0] — 2026-06-26
+
+Learnings from building a multi-link "stacked deck" for snippet cards (several links collapse into a notification-style stack that fans open; cards reorder in place), where the reorder had to live inside a card the parent list already made draggable / long-pressable.
+
+- **Stacked Deck & In-Place Reorder section (new)**: the notification-deck archetype (collapsed peek-stack → one-spring fan-out, peeks shrink + dim via `scaleEffect`/`brightness`, a glass count pill, the whole collapsed deck is one tap target) plus the reorder rule.
+- **Don't nest drag in drag**: a child `.draggable` inside an already drag/long-press-enabled parent makes nested recognizers fight for the same touch — and scoping the child drag to a grip handle does **not** fix it (the parent's long-press still arms there). Reorder with **discrete tap controls** (▲▼ buttons, fire on tap) instead — taps never compete with a long-press.
+- **Persist positionally in place**: rewrite the i-th data slot (e.g. reorder URL tokens within the text, leaving interleaved prose put; no-op unless counts match) so order survives reload.
+- Version output bumped to `⚙️ swiftui-microinteractions v1.13.0`
+
+---
+
 ## [1.12.0] — 2026-06-24
 
 Learnings from building LiquidGlassToastsView (Apple-style Liquid Glass toasts over an image grid, triggered by an icon-only glass button that cycles statuses via the SF Symbol replace transition).

--- a/SKILL.md
+++ b/SKILL.md
@@ -848,12 +848,59 @@ Button(action: trigger) {
 
 ---
 
+## Stacked Deck & In-Place Reorder
+
+A set of cards that lives **inside** a row that the parent already made
+draggable / long-pressable (a list item with `.draggable` or a `.contextMenu`).
+Two traps, one archetype.
+
+**Don't nest drag in drag.** A child `.draggable` inside an already
+drag/long-press-enabled parent makes nested recognizers fight for the same touch
+— the parent's long-press and the child's drag both arm on the same gesture arc,
+so neither feels reliable. Scoping the child drag to a small grip handle does
+**not** fix it; the parent's long-press still fires from that spot.
+
+- **Reorder with discrete tap controls, not drag.** Per-row up/down chevron
+  buttons (▲ disabled on the first row, ▼ on the last) that move an item one
+  slot. Buttons fire on *tap*, which never competes with a long-press, so reorder
+  works inside any card. This is the same fallback Apple uses where drag is
+  unavailable.
+- **Persist positionally in place.** Rewrite the i-th slot of the underlying data
+  (e.g. reorder URL tokens within the snippet text, leaving interleaved prose
+  exactly where it was; no-op unless counts match so text can't be mangled) so
+  the new order survives reload.
+
+**Notification-deck archetype** (collapsed peek-stack → fan open): lay every card
+in a `ZStack(alignment: .top)` and switch each card's geometry on one `isExpanded`
+spring.
+
+```swift
+let depth = CGFloat(min(index, maxPeeks))            // 0,1,2 — only top few peek
+card
+    .frame(height: rowHeight)
+    .scaleEffect(isExpanded ? 1 : 1 - depth * 0.05, anchor: .top)   // peeks shrink
+    .brightness(isExpanded ? 0 : -Double(depth) * 0.03)             // …and dim
+    .offset(y: isExpanded ? CGFloat(index) * rowStride              // fanned list
+                          : depth * peekStep)                       // stacked peek
+    .opacity(!isExpanded && index > maxPeeks ? 0 : 1)
+    .zIndex(Double(count - index))
+```
+
+- Collapsed, the whole deck is **one tap target** that expands (overlay a clear
+  `Button`); the cards underneath stay `allowsHitTesting(false)` until open.
+- A glass count pill (`rectangle.stack` + N) overlays the collapsed top card.
+- Container height is computed per state: `count * rowHeight + (count-1) * spacing`
+  expanded vs `rowHeight + min(count-1, maxPeeks) * peekStep` collapsed.
+- `mediumImpact` on expand/collapse; `selection` on each move.
+
+---
+
 ## Output (Create mode)
 
 Stream these progress lines one by one:
 
 ```
-⚙️  swiftui-microinteractions v1.12.0
+⚙️  swiftui-microinteractions v1.13.0
 🖼️  Assets: <found: name1, name2… · or · none found, using placeholders>
 🎯  Archetype: <archetype name>
 ⚡  Physics: <spring preset and why — one phrase>


### PR DESCRIPTION
Captures learnings from a multi-link "stacked deck" (several links collapse into a notification-style stack that fans open; cards reorder in place), where the reorder had to live inside a card the parent list already made draggable / long-pressable.

## New section — Stacked Deck & In-Place Reorder
- **Notification-deck archetype**: collapsed peek-stack → one-`isExpanded`-spring fan-out, peeks shrink + dim (`scaleEffect`/`brightness`), glass count pill, the whole collapsed deck is one tap target.
- **Don't nest drag in drag**: a child `.draggable` inside an already drag/long-press parent makes recognizers fight for the same touch; a grip handle does **not** fix it. Reorder with discrete ▲▼ tap buttons — taps never compete with long-press.
- **Persist positionally in place**: rewrite the i-th data slot (no-op unless counts match) so order survives reload.

Bumps version output to v1.13.0; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)