### PR TITLE
feat: v1.14.0 — genuine Liquid Glass rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: `[version] — date — summary`
 
 ---
 
+## [1.14.0] — 2026-06-26
+
+Strengthened the **iOS 26 Liquid Glass** section with a "use the genuine effect, always" rule.
+
+- **When a prompt says "Liquid Glass", use the real `.glassEffect`** — never fake it with a near-opaque material/tint as the primary surface (a `Capsule().fill(.ultraThinMaterial)` or heavy white-tinted glass reads as a flat chip, not glass). `.ultraThinMaterial` is the `< iOS 26` fallback only.
+- **Put busy, colorful content behind the glass** (image grid / photo / vivid gradient) so the refraction reads — a flat solid or pale background hides Liquid Glass and is the #1 reason a "glass" build looks wrong. For a standalone showcase, an image-tile grid backdrop is the safest way to make it pop.
+- Version output bumped to `⚙️ swiftui-microinteractions v1.14.0`
+
+---
+
 ## [1.13.0] — 2026-06-26
 
 Learnings from building a multi-link "stacked deck" for snippet cards (several links collapse into a notification-style stack that fans open; cards reorder in place), where the reorder had to live inside a card the parent list already made draggable / long-pressable.

--- a/SKILL.md
+++ b/SKILL.md
@@ -231,6 +231,11 @@ private var isDark: Bool { scheme == .dark }
 
 ## iOS 26 Liquid Glass
 
+**When the prompt says "Liquid Glass" → use the GENUINE effect, always.** Two non-negotiables:
+
+- **Real API, never a look-alike.** Use real `.glassEffect(.regular)` (or `.regular.interactive()` for a pressable control) on iOS 26. Do **not** fake it with a near-opaque fill as the *primary* surface — a `Capsule().fill(.ultraThinMaterial)` or a heavy `.glassEffect(.regular.tint(.white.opacity(0.5)))` reads as a flat chip, not glass. `.ultraThinMaterial` is the **< iOS 26 fallback only**, gated behind `if #available(iOS 26.0, *)`.
+- **Put busy, colorful content BEHIND the glass** so the refraction/specular actually reads — an image grid, a photo wall, a vivid gradient. On a flat solid or pale background Liquid Glass is nearly invisible and looks like plain material; that's the #1 reason a "glass" build looks wrong. (For a standalone showcase, an image-tile grid backdrop is the safest way to make the effect pop.)
+
 Use `.glassEffect()` on iOS 26+, fall back to `.ultraThinMaterial` on older OS. Always wrap in a `@ViewBuilder` helper so both paths share the same call site:
 
 ```swift
@@ -900,7 +905,7 @@ card
 Stream these progress lines one by one:
 
 ```
-⚙️  swiftui-microinteractions v1.13.0
+⚙️  swiftui-microinteractions v1.14.0
 🖼️  Assets: <found: name1, name2… · or · none found, using placeholders>
 🎯  Archetype: <archetype name>
 ⚡  Physics: <spring preset and why — one phrase>


### PR DESCRIPTION
Strengthens the **iOS 26 Liquid Glass** section with a 'use the genuine effect, always' rule:

- When a prompt says **Liquid Glass**, use the real `.glassEffect` — never a near-opaque material/tint as the primary surface (`.ultraThinMaterial` is the < iOS 26 fallback only).
- **Put busy/colorful content behind the glass** (image grid / photo / vivid gradient) so the refraction reads — a flat or pale background hides Liquid Glass and is the #1 reason a 'glass' build looks wrong.

Bumps version output to `⚙️ swiftui-microinteractions v1.14.0` + CHANGELOG.